### PR TITLE
Support Openempi 3.0.0 release fixes #1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,17 @@
-Role Name
+ansible-openempi
 ========
 
-openempi
+This role downloads and installs [openempi](http://www.openempi.org). You must use oracle java when running openempi.  This role by defualt is designed to work with these roles:
+* [ansible-java](https://github.com/yatesr/ansible-java)
+* [ansible-tomcat-standalone](https://github.com/yatesr/ansible-tomcat-standalone)
+* [ansible-postgresql](https://github.com/yatesr/ansible-postgresql)
 
 Role Variables
 --------------
 ```
 openempi_install_dir: /opt/openempi
-openempi_version: 3.0.0-beta
-openempi_download_url: https://kenai.com/projects/openempi/downloads/download/openempi-entity-{{openempi_version}}-openempi-entity.tar.gz
+openempi_version: 3.0.0
+openempi_download_url: "http://www.openempi.org/openempi-downloads/file_download/?username=odysseas@sysnetint.com&filename=openempi-entity-{{openempi_version}}-openempi-entity.tar.gz"
 # Default is for use with yatesr.tomcat-standalone role
 openempi_tomcat_dir: "{{tomcat_install_dir}}/apache-tomcat-{{tomcat_version}}"
 openempi_java_opts: "-Xms1024m -Xmx1024m -XX:NewSize=256m -XX:MaxNewSize=356m -XX:PermSize=256m -XX:MaxPermSize=356m"
@@ -33,12 +36,16 @@ Example Playbook
 
 ---
 - hosts: all
+  sudo: yes
   roles:
-  - yatesr.java-standalone
-  - yatesr.tomcat-standalone
-  - yatesr.ohie-cr
-
-
+   - ansible-java
+   - ansible-tomcat-standalone
+   - ansible-postgresql
+   - ansible-openempi
+  vars:
+   tomcat_version: 7.0.61 # Will need to be latest version
+   tomcat_user: openempi
+   tomcat_service: openempi
 ```
 
 License

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,8 @@
 ---
 openempi_install_dir: /opt/openempi
-openempi_version: 3.0.0-beta
-openempi_download_url: https://kenai.com/projects/openempi/downloads/download/openempi-entity-{{openempi_version}}-openempi-entity.tar.gz
+openempi_version: 3.0.0
+# Default download is for the 3.0.0 entity version
+openempi_download_url: "http://www.openempi.org/openempi-downloads/file_download/?username=odysseas@sysnetint.com&filename=openempi-entity-{{openempi_version}}-openempi-entity.tar.gz"
 # Default is for use with yatesr.tomcat-standalone role
 openempi_tomcat_dir: "{{tomcat_install_dir}}/apache-tomcat-{{tomcat_version}}"
 openempi_java_opts: "-Xms1024m -Xmx1024m -XX:NewSize=256m -XX:MaxNewSize=356m -XX:PermSize=256m -XX:MaxPermSize=356m"

--- a/tasks/cleanup.yml
+++ b/tasks/cleanup.yml
@@ -13,5 +13,6 @@
   sudo_user: postgres
   postgresql_db: name={{openempi_db_name}}
                  state=absent
+  ignore_errors: true
 
 


### PR DESCRIPTION
Adds support for 3.0.0 and new download URL.  Also updated documentation to show needed roles and options.  
